### PR TITLE
Add Elixir libs to the list of Backend Ethereum APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Pyethereum](https://github.com/ethereum/pyethereum) - The Python core library of the Ethereum project
 * [Eventeum](https://github.com/ConsenSys/eventeum) - A bridge between Ethereum smart contract events and backend microservices, written in Java by Kauri
 * [Ethereumex](https://github.com/exthereum/ethereumex) - Elixir JSON-RPC client for the Ethereum blockchain
+* [EthContract](https://github.com/AgileAlpha/eth_contract) - A set of helper methods to help query ETH smart contracts in Elixir
 
 #### Bootstrap/out of box tools
 * [Truffle boxes](http://truffleframework.com/boxes/) - Packaged components for the Ethereum ecosystem

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [KEthereum](https://github.com/walleth/kethereum) - Kotlin Web3
 * [Pyethereum](https://github.com/ethereum/pyethereum) - The Python core library of the Ethereum project
 * [Eventeum](https://github.com/ConsenSys/eventeum) - A bridge between Ethereum smart contract events and backend microservices, written in Java by Kauri
+* [Ethereumex](https://github.com/exthereum/ethereumex) - Elixir JSON-RPC client for the Ethereum blockchain
 
 #### Bootstrap/out of box tools
 * [Truffle boxes](http://truffleframework.com/boxes/) - Packaged components for the Ethereum ecosystem


### PR DESCRIPTION
I'm not affiliated with the guys who made Ethereumex, but think it should be on the list.
Also added a EthContract - helper library for calling smart contracts.