### PR TITLE
Added EthSum

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [truffle-flattener](https://github.com/alcuadrado/truffle-flattener) - Concats solidity files developed under Truffle with all of their dependencies
 * [Decode](https://github.com/dteiml/decode) - npm package which parses tx's submitted to a local testrpc node to make them more readable and easier to understand
 * [TypeChain](https://github.com/Neufund/TypeChain) - Typescript bindings for Ethereum smartcontracts
+* [EthSum] (https://ethsum.netlify.com) - A Simple Ethereum Address Checksum Tool
 
 ### Smart Contract Standards & Libraries
 #### [ERCs](https://eips.ethereum.org/erc) - The Ethereum Request for Comment repository


### PR DESCRIPTION
EthSum is a web Ethereum address checksum tool and I'm its author. It's handy to have it in the browser, as not all exchanges or dApps verify the checksum.