### PR TITLE
Adding Ethereum on Azure to test net list

### DIFF
--- a/Tools.md
+++ b/Tools.md
@@ -59,6 +59,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Local Raiden](https://github.com/ConsenSys/Local-Raiden) - Run a local Raiden network in docker containers for demo and testing purposes
 * [Private networks deployment scripts](https://github.com/ConsenSys/private-networks-deployment-scripts) - Out-of-the-box deployment scripts for private PoA networks
 * [Local Ethereum Network](https://github.com/ConsenSys/local_ethereum_network) - Out-of-the-box deployment scripts for private PoW networks
+* [Ethereum on Azure](https://docs.microsoft.com/en-us/azure/blockchain-workbench/ethereum-poa-deployment) - Deployment and governance of consortium Ethereum PoA networks
 
 #### Test Ether faucets
 * [Rinkeby faucet](https://faucet.rinkeby.io/)


### PR DESCRIPTION
Ethereum on Azure allows you to configure and deploy a PoA test network in Azure cloud.