### PR TITLE
Added truffle-assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Solhint](https://github.com/protofire/solhint) - Solidity linter that provides security, style guide and best practice rules for smart contract validation
 * [Solium](https://github.com/duaraghav8/Solium) - Linter to identify and fix style & security issues in Solidity
 * [Decode](https://github.com/dteiml/decode) - npm package which parses tx's submitted to a local testrpc node to make them more readable and easier to understand
+* [truffle-assertions](https://github.com/rkalis/truffle-assertions) - An npm package with additional assertions and utilities used in testing Solidity smart contracts with truffle. Most importantly, it adds the ability to assert whether specific events have (not) been emitted.
 
 ### Security Tools
 * [Mythril](https://github.com/ConsenSys/mythril) - Static smart contract security analysis


### PR DESCRIPTION
I added my `truffle-assertions` library, which is used mainly to assert that specific events with a specified event type have been emitted. The library also takes a filter function on the event arguments, allowing the developer to make the assertions as coarse or as fine-grained as needed.