### PR TITLE
Updating name of Linnia to Stow

### DIFF
--- a/EcosystemResources.md
+++ b/EcosystemResources.md
@@ -140,7 +140,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Gnosis Dutch Exchange](https://github.com/gnosis/dx-contracts)
 
 ### Secure Decentralized Data Protocols
-* [Linnia](https://linnia.com) - Securely store and share data for your users in minutes with our components and SDK
+* [Stow](https://stow-protocol.com/) - Securely store and share data for your users in minutes with our components and SDK.  Formerly Linnia.
 
 ### Incentivisation / Monetisation Tools
 * [Gitcoin](https://gitcoin.co) - Bounty network for funding Open Source or finding Open Source work


### PR DESCRIPTION
Linnia has a new name, Stow.  Also linnia has a new website