### PR TITLE
Add sbt-ethereum to frameworks list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Parasol](https://github.com/Lamarkaz/parasol) - Agile smart contract development environment with testing, INFURA deployment, automatic contract documentation and more. It features a a flexible and unopinionated design with unlimited customizability
 * [0xcert](https://github.com/0xcert/framework/) - JavaScript framework for building decentralized applications 
 * [ZeppelinOS](https://zeppelinos.org/) - ZeppelinOS is a development platform designed specifically for smart contract projects and allows developers to create Upgradable smart contracts and create and link to EVM packages as a form of on-chain library code.
+* [sbt-ethereum](https://www.sbt-ethereum.io/) - A tab-completey, text-based console for smart-contract interaction and development, including wallet and ABI management, ENS support, and advanced Scala integration.
 
 #### IDEs
 * [Remix](https://remix.ethereum.org/) - Web IDE with built in static analysis, test blockchain VM.


### PR DESCRIPTION
[sbt-ethereum](https://www.sbt-ethereum.io) is an open-source Ethereum development and interaction framework I've been working on for a while. Would it be suitable to add to the frameworks list?

Many thanks.