### PR TITLE
rebrand instances of Oraclize to Provable

### DIFF
--- a/EcosystemResources.md
+++ b/EcosystemResources.md
@@ -58,7 +58,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [CryptoProf](https://github.com/doc-ai/cryptoprof) - Gas profiler for smart contracts
 
 ### Services
-* [Oraclize](http://docs.oraclize.it/#ethereum) - Oracle service backed by authenticity proofs, for your smart contracts
+* [Provable](http://docs.provable.xyz/#ethereum) - Blockchain oracle service backed by authenticity proofs, for your smart contracts
 * [Infura](https://infura.io/) - API gateway so you don't have to host your own ETH node
 * [Quiknode](https://quiknode.io/) - Service to spin up personal Parity/Geth nodes
 * [Regis](https://regis.nu/) - Registry Framework for Digital Assets

--- a/EcosystemResources_Japanese.md
+++ b/EcosystemResources_Japanese.md
@@ -58,7 +58,7 @@ Ethereumエコシステムを学習・理解するためのDApps、サービス�
 * [CryptoProf](https://github.com/doc-ai/cryptoprof) - スマートコントラクトのgasプロファイラ 
 
 ### サービス
-* [Oracalize](http://www.oraclize.it/) - スマートコントラクトのためのOracleサービス 
+* [Provable](http://provable.xyz/) - スマートコントラクトのためのOracleサービス
 * [Infura](https://infura.io/) - EthereumのAPIゲートウェイ。自分のEthereumホストを立ち上げなくて済む
 * [Quiknode](https://quiknode.io/) - Parity/Gethのノードをスピンアップするサービス
 * [Regis](https://regis.nu/) - デジタル資産の登録サービス 

--- a/EcosystemResources_Korean.md
+++ b/EcosystemResources_Korean.md
@@ -56,7 +56,7 @@ Meridio를 설립한 [@corbpage](https://twitter.com/corbpage), 확장과 큐레
 * [크립토프로프(CryptoProf)](https://github.com/doc-ai/cryptoprof) - 스마트 컨트렉트를 위한 가스 프로파일러(profiler) 입니다.
 
 ### 서비스
-* [오라칼리즈(Oracalize)](http://www.oraclize.it/) - 당신의 스마트 컨트렉트를 위한 오라클(Oracle) 서비스 입니다.
+* [프로보빌(Provable)](http://provable.xyz/) - 당신의 스마트 컨트렉트를 위한 오라클(Oracle) 서비스 입니다.
 * [인퓨라(Infura)](https://infura.io/) - ETH 노드를 소유할 필요없는 API 게이트웨이 입니다.
 * [퀵노드(Quiknode)](https://quiknode.io/) - 개인 패리티(Parity)/게스(Geth) 노드를 돌려주는 서비스 입니다.
 * [레지스(Regis)](https://regis.nu/) - 디지털 자산을 위한 레지스트리(Registry) 프레임워크 입니다.

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [ARC](https://github.com/daostack/arc) - an operating system for DAOs and the base layer of the DAO stack.
 * [0x](https://github.com/0xProject) - DEX protocol
 * [Token Libraries with Proofs](https://github.com/sec-bit/tokenlibs-with-proofs) - Contains correctness proofs of token contracts wrt. given specifications and high-level properties
-* [Oraclize API](https://github.com/oraclize/ethereum-api) - Provides contracts for using the Oraclize service, allowing for off-chain actions, data-fetching, and computation
+* [Provable API](https://github.com/provable-things/ethereum-api) - Provides contracts for using the Provable service, allowing for off-chain actions, data-fetching, and computation
 
 
 ### Developer Guides for 2nd Layer Infrastructure


### PR DESCRIPTION
As Oraclize has rebranded to Provable, it would be useful to update instances of Oraclize here to avoid confusion. 

Attempted phonetic transliteration of Provable for Korean, which it appeared to be the case with Oraclize, should be sufficient in current state but probably best checked by a Korean speaker.