### PR TITLE
Added solc-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Manticore](https://github.com/trailofbits/manticore) - Symbolic execution tool on Smart Contracts and Binaries
 * [Slither](https://github.com/trailofbits/slither) - A Solidity static analysis framework
 * [Adelaide](https://github.com/sec-bit/adelaide) - The SECBIT static analysis extension to Solidity compiler
+* [solc-verify](https://github.com/SRI-CSL/solidity/) - A modular verifier for Solidity smart contracts
 * [Solidity security blog](https://github.com/sigp/solidity-security-blog) - Comprehensive list of known attack vectors and common anti-patterns
 * [Awesome Buggy ERC20 Tokens](https://github.com/sec-bit/awesome-buggy-erc20-tokens) - A Collection of Vulnerabilities in ERC20 Smart Contracts With Tokens Affected
 * [Free Smart Contract Security Audit](https://callisto.network/smart-contract-audit/) - Free smart contract security audits from Callisto Network


### PR DESCRIPTION
Solc-verify is a modular verifier for Solidity built on top of the Solidity compiler. For more info see:
- Paper: https://arxiv.org/abs/1907.04262
- Readme in the repo: https://github.com/SRI-CSL/solidity/blob/boogie-devel/SOLC-VERIFY-README.md