### PR TITLE
Added dfuse, a blockchain APIs service company

### DIFF
--- a/EcosystemResources.md
+++ b/EcosystemResources.md
@@ -49,6 +49,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Etherchain lite](https://github.com/gobitfly/etherchain-light) - Lightweight blockchain explorer for your private Ethereum chain
 * [EthStats](https://ethstats.io/) - The Ethereum Blockchain Analytics Platform
 * [Scout](https://scout.cool/) - A live data feed of the activities and event logs of your smart contracts on Ethereum
+* [ethq](https://ethq.app) - The [dfuse](https://dfuse.io) powered, most detailed, block explorer built for developers
 
 ### Gas price calculators and tools
 * [EthGasStation](https://ethgasstation.info/) - Website for estimating tx prices vs times
@@ -60,6 +61,7 @@ Many thanks to the 20+ contributors including [@corbpage](https://twitter.com/co
 * [Infura](https://infura.io/) - API gateway so you don't have to host your own ETH node
 * [Quiknode](https://quiknode.io/) - Service to spin up personal Parity/Geth nodes
 * [Nodesmith](https://nodesmith.io/) - Free API access to full Ethereum mainnet and testnet nodes, can be used just like a local node
+* [dfuse](https://dfuse.io) - Slick blockchain APIs to build world-class applications.
 * [Regis](https://regis.nu/) - Registry Framework for Digital Assets
 * [Viant](https://viant.io/) - Just consider using Viant as your backend if the use case is business process oriented
 * [uPort](https://www.uport.me/) - Total identity solution

--- a/EcosystemResources_Japanese.md
+++ b/EcosystemResources_Japanese.md
@@ -51,6 +51,7 @@ Ethereumエコシステムを学習・理解するためのDApps、サービス�
 * [Etherchain Light](https://github.com/gobitfly/etherchain-light) - Ethereumのプライベートチェーン用の軽量ブロックチェーン・エクスプローラ
 * [Alethio EthStats 2.0](https://media.consensys.net/alethio-lighting-up-the-blockchain-with-real-time-stats-a80bb30576db) coming soon
 * [Supermax](https://www.supermax.cool/) - Ethereumスマートコントラクトのアクティビティ、Event logのライブデータフィード
+* [ethq](https://ethq.app) - 開発者向けに構築された[dfuse](https://dfuse.io)を搭載した最も詳細なブロックエクスプローラー
 
 ### gas計算&ツール
 * [EthGasStation](https://ethgasstation.info/) - トランザクションの価格と時間を見積もるWebサイト  
@@ -61,6 +62,7 @@ Ethereumエコシステムを学習・理解するためのDApps、サービス�
 * [Provable](http://provable.xyz/) - スマートコントラクトのためのOracleサービス
 * [Infura](https://infura.io/) - EthereumのAPIゲートウェイ。自分のEthereumホストを立ち上げなくて済む
 * [Quiknode](https://quiknode.io/) - Parity/Gethのノードをスピンアップするサービス
+* [dfuse](https://dfuse.io) - 世界クラスのアプリケーションを構築するための滑らかなブロックチェーンAPI。
 * [Regis](https://regis.nu/) - デジタル資産の登録サービス 
 * [Viant](https://viant.io/) - ビジネスプロセスの用途ならViantをバックエンドに利用することを検討してください 
 * [uPort](https://www.uport.me/) - 総合IDソリューション 

--- a/EcosystemResources_Korean.md
+++ b/EcosystemResources_Korean.md
@@ -49,6 +49,7 @@ Meridio를 설립한 [@corbpage](https://twitter.com/corbpage), 확장과 큐레
 * [이더체인 라이트(Etherchain Light)](https://github.com/gobitfly/etherchain-light)- 당신의 프라이빗 이더리움 체인을 위한 가벼운 블록체인 익스플로러 입니다.
 * [EthStats](https://ethstats.io/) - 이더리움 블록체인 분석 플랫폼 입니다.
 * [Scout](https://www.scout.cool/) - 이더리움 안에서 당신의 스마트 컨트렉트의 이벤트 로그와 활동을 바로(live) 데이터 피드(data feed) 합니다.
+* [ethq](https://ethq.app) - 개발자를 위해 구축 된 [dfuse](https://dfuse.io) 기반의 가장 세부적인 블록 탐색기
 
 ### 가스 가격 계산기와 도구
 * [이더가스스테이션(EthGasStation)](https://ethgasstation.info/) - 실시간 거래가격 추산을 위한 웹사이트 입니다.
@@ -59,6 +60,7 @@ Meridio를 설립한 [@corbpage](https://twitter.com/corbpage), 확장과 큐레
 * [프로보빌(Provable)](http://provable.xyz/) - 당신의 스마트 컨트렉트를 위한 오라클(Oracle) 서비스 입니다.
 * [인퓨라(Infura)](https://infura.io/) - ETH 노드를 소유할 필요없는 API 게이트웨이 입니다.
 * [퀵노드(Quiknode)](https://quiknode.io/) - 개인 패리티(Parity)/게스(Geth) 노드를 돌려주는 서비스 입니다.
+* [dfuse](https://dfuse.io) - 세계적 수준의 애플리케이션을 구축하기위한 매끄러운 블록 체인 API.
 * [레지스(Regis)](https://regis.nu/) - 디지털 자산을 위한 레지스트리(Registry) 프레임워크 입니다.
 * [바이안트(Viant)](https://viant.io/) - 유스케이스가 비즈니스 프로세스 지향적인 경우에 백엔드를 바이안트로 사용하세요.
 * [유포트(uPort)](https://www.uport.me/) - 통합 아이덴티티(identity) 솔루션 입니다.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Cobra](https://github.com/cobraframework/cobra) - A fast, flexible and simple development environment framework for Ethereum smart contract, testing and deployment on Ethereum virtual machine(EVM).
 * [Fortmatic](https://fortmatic.com/) - A simple to use SDK to build web3 dApps without extensions or downloads.
 * [Portis](https://portis.io/) - A non-custodial wallet with an SDK that enables easy interaction with DApps without installing anything.
+* [dfuse](https://dfuse.io) - Slick blockchain APIs to build world-class applications.
 
 ## Developer Tools
 ### Developing Smart Contracts
@@ -138,6 +139,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
     * [ez-ens](https://github.com/merklejerk/ez-ens) Simple, zero-configuration Ethereum Name Service address resolver.
     * [web3x](https://github.com/xf00f/web3x) - A TypeScript port of web3.js. Benefits includes tiny builds and full type safety, including when interacting with contracts. 
 * [Nethereum](https://github.com/Nethereum/) - Cross-platform Ethereum development framework 
+* [dfuse](https://github.com/dfuse-io/client-js) - A TypeScript library to use [dfuse Ethereum API](https://dfuse.io)
 * [Drizzle](https://github.com/truffle-box/drizzle-box) - Redux library to connect a frontend to a blockchain
 * [Tasit SDK](https://github.com/tasitlabs/tasitsdk) - A JavaScript SDK for making native mobile Ethereum dapps using React Native
 * [Subproviders](https://github.com/0xProject/0x-monorepo/tree/v2-prototype/packages/subproviders) - Several useful subproviders to use in conjunction with [Web3-provider-engine](https://github.com/MetaMask/provider-engine/) (including a LedgerSubprovider for adding Ledger hardware wallet support to your dApp)

--- a/README_Japanese.md
+++ b/README_Japanese.md
@@ -26,6 +26,7 @@ Ethereum開発で利用可能なツール、コンポーネント、パターン
 * [Truffle](http://truffleframework.com) - もっともポピュラーなスマートコントラクトの開発、テスト、デプロイ用フレームワーク。npmでインストールしこのツールで最初のスマートコントラクトを書いてみてください。
 * [Metamask](https://metamask.io/) - DAppsと連携するChrome拡張ウォレット。
 * [Truffle boxes](http://truffleframework.com/boxes/) - Ethereumエコシステムのためのパッケージされたコンポーネント。
+* [dfuse](https://dfuse.io) - 世界クラスのアプリケーションを構築するための滑らかなブロックチェーンAPI。
 
 ## 開発ツール
 ### スマートコントラクト開発
@@ -77,6 +78,7 @@ Ethereum開発で利用可能なツール、コンポーネント、パターン
     * [Ethereumjs](https://github.com/ethereumjs/) - [ethereumjs-util](https://github.com/ethereumjs/ethereumjs-util) や [ethereumjs-tx](https://github.com/ethereumjs/ethereumjs-tx)のようなEthereumのユーティリティ集
 
 * [Drizzle](https://github.com/truffle-box/drizzle-box) -  フロントエンドからブロックチェーンに繋ぐためのReduxライブラリ
+* [dfuse](https://github.com/dfuse-io/client-js) - [dfuse Ethereum API](https://dfuse.io)を使用するTypeScriptライブラリ
 * [Subproviders](https://github.com/0xProject/0x-monorepo/tree/v2-prototype/packages/subproviders) - [Web3-provider-engine](https://github.com/MetaMask/provider-engine/) と接続するためのいくつかの便利なsubproviders(ハードウェアウォレットLedgerサポートをdAppに追加するためのLedgerSubproviderを含む)
 * [web3-webpacked](https://github.com/NoahHydro/web3-webpacked) - Web3を利用するためのJSフレームワーク。
 * [Vortex](https://github.com/Horyus/vortex) - DApp対応したReduxストア。WebSocketでスマートでダイナミックなバックグラウンドデータの更新が可能。 [Truffle](https://github.com/Horyus/vortex-demo)と[Embark](https://github.com/Horyus/vortex-demo-embark)で利用可能。

--- a/README_Korean.md
+++ b/README_Korean.md
@@ -62,6 +62,7 @@
 * [메타마스크(Metamask)](https://metamask.io/) - 크롬 확장 지갑으로 탈중앙화 어플리케이션과 작동합니다.
 * [트러플 박스(Truffle boxes)](https://truffleframework.com/boxes/) - 이더리움 생태계를 위한 패키지 컴포넌트 입니다.
 * [EthHub.io](https://docs.ethhub.io/) - 이더리움의 개요 (역사, 거버넌스, 향후 계획, 개발 리소스)가 있는 종합적인 크라우드 소스(crowdsourced)입니다.
+* [dfuse](https://dfuse.io) - 매끄러운 블록 체인 API로 세계적 수준의 애플리케이션을 구축하십시오.
 <a name="개발도구"></a>
 ## 개발 도구
 
@@ -128,6 +129,7 @@
     * [ez-ens](https://github.com/merklejerk/ez-ens) 간단하며, 제로 구성(zero-configuration) 이더리움 이름 서비스(Ethereum Name Service) 주소 해결책 입니다.
     * [web3x](https://github.com/xf00f/web3x) - web3.js의 타입스크립트 포트 입니다. 컨트렉트 상호작용이 포함되어 모든 타입의 보안(safety)과 작은 빌드의 이점이 있습니다.
 * [드리즐(Drizzle)](https://github.com/truffle-box/drizzle-box) - 리덕스(Redux) 라이브러리 블록체인 프론트엔드와 연결합니다.
+* [dfuse](https://github.com/dfuse-io/client-js) - [dfuse Ethereum API](https://dfuse.io)를 사용하는 TypeScript 라이브러리
 * [Tasit SDK](https://github.com/tasitlabs/tasitsdk) - 리엑트 네이티브(React Native)를 사용하여 모바일 이더리움 dapps를 만들기 위한 자바스크립트 SDK 입니다.
 * [Subproviders](https://github.com/0xProject/0x-monorepo/tree/v2-prototype/packages/subproviders) - [웹3 프로바이더 엔진(Web3-provider-engine)](https://github.com/MetaMask/provider-engine/) 과 함께 사용되는 여러가지 유용한 subproviders 입니다. (당신의 탈중앙화 어플리케이션을 지원하는 렛저(Ledger) 하드웨어 월렛을 위한 LedgerSubprovider를 포함합니다.)
 * [web3-react](https://github.com/NoahZinsmeister/web3-react) - 싱글페이지(single-page) 이더리움 dApps를 빌딩하기 위한 리액트 프레임워크 입니다.


### PR DESCRIPTION
Added dfuse, a blockchain APIs service company that provides powerful detailed API to retrieve and consume data from Ethereum blockchains (and others).

We offer a GraphQL query & subscription based operation to search the entire chain while only giving you the transactions you only care about using a simple GitHub like query language. You get the most detailed view the transaction being able to track inner contract EVM calls, balance changes, state changes and more.