### PR TITLE
update infrastructure, add quiknode.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Quorum](https://github.com/jpmorganchase/quorum) - A permissioned implementation of Ethereum supporting data privacy by [JP Morgan](https://www.jpmorgan.com/quorum)
 * [Mana](https://github.com/mana-ethereum/mana) - Ethereum full node implementation written in Elixir.
 * [Chainstack](https://chainstack.com/) - A managed service providing shared and dedicated Geth nodes
+* [QuikNode](https://quiknode.io/) - Blockchain developer cloud with API access and node-as-a-service.
+
 
 #### Storage
 * [IPFS](https://ipfs.io/) - Decentralised storage and file referencing


### PR DESCRIPTION
QuikNode API = free access to ETH MainNet for dev, or users can upgrade to a dedicated node (Geth or Parity)