### PR TITLE
Add truffle-plugin-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Resolver-Engine](https://github.com/Crypto-Punkers/resolver-engine) - A set of tools to standarize Solidity import and artifact resolution in frameworks.
 * [eth-reveal](https://github.com/justinjmoses/eth-reveal) - A node and browser tool to inspect transactions - decoding where possible the method, event logs and any revert reasons using ABIs found online. 
 * [Ethereum-tx-sender](https://github.com/HydroProtocol/ethereum-tx-sender) - A useful library written in Golang to reliably send a transaction — abstracting away some of the tricky low level details such as gas optimization, nonce calculations, synchronization, and retries.
+* [truffle-plugin-verify](https://github.com/rkalis/truffle-plugin-verify) - Seamlessly verify contract source code on Etherscan from the Truffle command line.
 
 ### Smart Contract Standards & Libraries
 #### [ERCs](https://eips.ethereum.org/erc) - The Ethereum Request for Comment repository


### PR DESCRIPTION
truffle-plugin-verify allows you to verify your smart contract source code on Etherscan with a single command from the Truffle command line. Couldn't be easier!

```
truffle run verify SimpleStorage --network rinkeby
```