### PR TITLE
Add CI check for broken links

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,10 @@
+name: Markdown Links Check
+
+on: [push, pull_request]
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
Because this list was compiled over several years, some of the links in this list are now broken. This PR uses [github action markdown link check](https://github.com/gaurav-nelson/github-action-markdown-link-check) to check for broken links. After broken links are identified, the next step can be to remove or fix the links.

Because there are broken links, this PR will cause the CI system to trigger a failure on future PRs until the links are fixed. This can be changed by modifying the `on: [push, pull_request]` line to `on: [push]` to avoid running this action on PRs.