### PR TITLE
Adding distribution category and Meroku as a tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
       - [Ethereum Clients](#ethereum-clients)
       - [Storage](#storage)
       - [Messaging](#messaging)
+    - [Distribution](#distribution)
     - [Testing Tools](#testing-tools)
     - [Security Tools](#security-tools)
     - [Monitoring](#monitoring)
@@ -317,6 +318,9 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [DEVp2p Wire Protocol](https://github.com/ethereum/devp2p/blob/master/rlpx.md) - Peer-to-peer communications between nodes running Ethereum/Whisper
 * [Pydevp2p](https://github.com/ethereum/pydevp2p) - Python implementation of the RLPx network layer
 * [3Box Threads](https://docs.3box.io/api/messaging) - API to allow developers to implement IPFS persisted, or in memory peer to peer messaging.
+
+### Distribution
+* [Meroku](https://github.com/merokudao/meroku) - A community owned dApp Store. Package, distribute your dApp without hosting costs.
 
 ### Testing Tools
 * [Truffle Teams](https://trufflesuite.com/teams) - Zero-Config continuous integration for truffle projects


### PR DESCRIPTION
This PR adds 

1. A category called distribution. As the dApp ecosystem continues to grow, this category will become important and have more tools coming in.
2. Meroku as the first tool in this category.