### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [EWF Parity](https://github.com/energywebfoundation/energyweb-ui) - Energy Web Foundation client for the Tobalaba test network
 * [Quorum](https://github.com/jpmorganchase/quorum) - A permissioned implementation of Ethereum supporting data privacy by [JP Morgan](https://jpmorgan.com/quorum)
 * [Mana](https://github.com/mana-ethereum/mana) - Ethereum full node implementation written in Elixir.
-* [Chainstack](https://chainstack.com/) - A managed service providing shared and dedicated Geth nodes
+* [Chainstack](https://chainstack.com/) - A managed service providing elastic and dedicated Geth nodes
 * [QuickNode](https://quicknode.com/) - Blockchain developer cloud with API access and node-as-a-service.
 * [Watchdata](https://watchdata.io) - Provide simple and reliable API access to Ethereum blockchain
 * [NOWNodes](https://nownodes.io) - Provide access to ETH node (and 48+ more) and Block Explorer. Get free API key to test blockchain-as-a-service solution


### PR DESCRIPTION
Chainstack renamed **shared** nodes to **elastics** nodes, as it is more representative of the technology involved.