### PR TITLE
removed Openzeppelin Starter Kit Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Hardhat](https://hardhat.org/) - Flexible, extensible and fast Ethereum development environment.
 * [Foundry](https://book.getfoundry.sh/) - Smart contract development toolchain. Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line.
 * [Cryptotux](https://cryptotux.org/) - A Linux image ready to be imported in VirtualBox that includes the development tools mentionned above
-* [OpenZeppelin Starter Kits](https://openzeppelin.com/starter-kits/) - An all-in-one starter box for developers to jumpstart their smart contract backed applications. Includes Truffle, OpenZeppelin SDK, the OpenZeppelin/contracts-ethereum-package EVM package of audited smart contract, a react-app and rimble for easy styling.
+* [OpenZeppelin Wizards](https://docs.openzeppelin.com/contracts/4.x/wizard) - Not sure where to start? Use the interactive generator to bootstrap your contract and learn about the components offered in OpenZeppelin Contracts.
 * [EthHub.io](https://docs.ethhub.io/) - Comprehensive crowdsourced overview of Ethereum- its history, governance, future plans and development resources.
 * [EthereumDev.io](https://ethereumdev.io) - The definitive guide for getting started with Ethereum smart contract programming.
 * [Brownie](https://github.com/iamdefinitelyahuman/brownie) - Brownie is a Python framework for deploying, testing and interacting with Ethereum smart contracts.


### PR DESCRIPTION
OpenZeppelin Starter Kits has been deprecated. [Starter Kits](https://docs.openzeppelin.com/starter-kits/)
Link  provided was dead [Starter Kits](https://openzeppelin.com/starter-kits/).
Replaced link with suitable OpenZeppelin replacement, OpenZeppelin Wizards, which walks a new developer through creating an OZ contract.