### PR TITLE
Add ethereum-datafarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Ethernal](https://www.tryethernal.com) - Ethereum block explorer for private chain. Browse transactions, decode function calls, event data or contract variables values on your locally running chain.
 * [Forta](https://forta.org/) - A decentralized monitoring network to detect threats and anomalies on DeFi, NFT, governance, bridges and other Web3 systems in real-time.
 * [InfStones BlockWatch](https://infstones.com/block_watch) - Set up alarms to monitor node status for resource utilization. Incorporate notifications for SMS, Slack, phone calls, and emails.
+* [Ethereum-datafarm](https://github.com/Nerolation/ethereum-datafarm) - Easy-to-use console app for parsing historical event data without requiring an archive node. Ethereum-datafarm uses the Etherscan API to parse event data from specified contracts and store it in CSV format.
 
 ### Other Miscellaneous Tools
 * [aragonPM](https://hack.aragon.org/docs/apm-intro.html) - a decentralized package manager powered by aragonOS and Ethereum. aragonPM enables decentralized governance over package upgrades, removing centralized points of failure.


### PR DESCRIPTION
Ethereum datafarm was mainly created with the focus to enable economic/business students (who do have the knowledge to to quantitative analysis on cryptocurrencies but lack of CS knowledge to scrap data from the chain) easy access though a wrapper around the Etherscan api.

For example, users can plug in the uniswap contracts, parse the event data and use the information to do further price analysis.

I have received great feedback so far and I think the tool may provide many people access to Ethereum!