### PR TITLE
Add EPNS SNS Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [DEVp2p Wire Protocol](https://github.com/ethereum/devp2p/blob/master/rlpx.md) - Peer-to-peer communications between nodes running Ethereum/Whisper
 * [Pydevp2p](https://github.com/ethereum/pydevp2p) - Python implementation of the RLPx network layer
 * [3Box Threads](https://docs.3box.io/api/messaging) - API to allow developers to implement IPFS persisted, or in memory peer to peer messaging.
+* [EPNS SNS Notifications](https://docs.epns.io/developers/developer-zone/receiving-notifications/sns-notifications) - SNS module for Push Delivery Nodes allows any developer to receive notifications, chats, or any other form of web3 communication directly to the platform they are building with the help of webhooks.
 
 ### Testing Tools
 * [Truffle Teams](https://trufflesuite.com/teams) - Zero-Config continuous integration for truffle projects


### PR DESCRIPTION
# SNS module for Push Delivery Nodes

SNS module for Push Delivery Nodes allows any developer to receive notifications, chats, or any other form of web3 communication directly to the platform they are building with the help of webhooks.

Hosted SNS Module is a mid-level solution that eliminates all the heavy load of running a node or syncing information and gives you webhooks that you implement to start receiving notifications, chats, or any other web3 communication in your software.

## About EPNS

Ethereum Push Notification Service (EPNS) is the world’s first decentralized communication & notification protocol for Web3.
 
Using the protocol, any smart contract, dApp, or backend service can send on-chain or off-chain notifications tied to the wallet addresses of users in a gasless, multichain, open, and platform-agnostic way.

Being an open communication middleware, notifications can be integrated and shown on any crypto wallet, mobile app, browser extension, or dApps enabling a native communication layer for Web3.0

## More info about SNS module 
* Official Docs: https://docs.epns.io/developers/developer-zone/receiving-notifications/sns-notifications
* SNS Integration Template: https://github.com/ethereum-push-notification-service/epns-sns-boilerplate
* Twitter thread announcement: https://twitter.com/epnsproject/status/1560271342255030272?s=20&t=63NQNjy4oZlonbMDuE6bfg