### PR TITLE
Add Smart Contract GUI to ABI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Nethereum-CodeGenerator](https://github.com/StefH/Nethereum-CodeGenerator) - A web based generator which creates a Nethereum based C# Interface and Service based on Solidity Smart Contracts.
 * [EVMConnector](https://evmconnector.dev) - Create shareable contract dashboards and interact with arbitrary EVM-based blockchain functions, with or without an ABI.
 * [contract-admin](https://github.com/upgreidas/contract-admin) - Minimalistic UI tool for interacting with your smart contracts
+* [Smart Contract GUI](https://smartcontractgui.xyz) - Instant access to read from and write to any smart contract directly (on any EVM chain) by simply uploading the ABI. A simple and powerful UX enables rapid execution of smart contract calls locally, on testnets and mainnets. It also comes packed with a host of useful tools for integration testing. 
 
 #### Patterns & Best Practices
 


### PR DESCRIPTION
This PR is to add the Smart Contract GUI to ABI tools.

The Smart Contract GUI is a battle-tested tool that is built and maintained by [Massless](https://massless.io). It has been used for integration testing across many major projects with smart contracts totaling over $25million in revenue.

We have found the Smart Contract GUI invaluable and we can't think of a better way to give back to the awesome web3 community than by providing access and support for free.

![Untitled](https://user-images.githubusercontent.com/602085/194420868-1da2930c-0fcf-4de8-83d1-74cbf38a0a4e.png)