### PR TITLE
removed mesg-foundation/service-ethereum-contract and mesg-foundation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Ethereumex](https://github.com/mana-ethereum/ethereumex) - Elixir JSON-RPC client for the Ethereum blockchain
 * [Ethereum-jsonrpc-gateway](https://github.com/HydroProtocol/ethereum-jsonrpc-gateway) - A gateway that allows you to run multiple Ethereum nodes for redundancy and load-balancing purposes. Can be ran as an alternative to (or on top of) Infura. Written in Golang.
 * [EthContract](https://github.com/AgileAlpha/eth_contract) - A set of helper methods to help query ETH smart contracts in Elixir
-* [Ethereum Contract Service](https://github.com/mesg-foundation/service-ethereum-contract) - A MESG Service to interact with any Ethereum contract based on its address and ABI.
-* [Ethereum Service](https://github.com/mesg-foundation/service-ethereum) - A MESG Service to interact with events from Ethereum and interact with it.
 * [Marmo](https://marmo.io/) - Python, JS, and Java SDK for simplifying interactions with Ethereum. Uses relayers to offload transaction costs to relayers.
 * [Ethereum Logging Framework](https://bitbucket.csiro.au/users/kli039/repos/ethereum-logging-framework/browse) - provides advanced logging capabilities for Ethereum applications and networks including a query language, query processor, and logging code generation
 * [Watchdata](https://watchdata.io) - Provide simple and reliable API access to Ethereum blockchain


### PR DESCRIPTION
removed
- mesg-foundation/service-ethereum-contract
- [mesg-foundatio](https://github.com/mesg-foundation/service-ethereum)

because it gives 404