### PR TITLE
Contract Verification Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
       - [Ethereum Clients](#ethereum-clients)
       - [Storage](#storage)
       - [Messaging](#messaging)
+    - [Source Code Verification](#source-code-verification)
     - [Distribution](#distribution)
     - [Testing Tools](#testing-tools)
     - [Security Tools](#security-tools)
@@ -351,6 +352,11 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Pydevp2p](https://github.com/ethereum/pydevp2p) - Python implementation of the RLPx network layer
 * [3Box Threads](https://docs.3box.io/api/messaging) - API to allow developers to implement IPFS persisted, or in memory peer to peer messaging.
 * [EPNS SNS Notifications](https://docs.epns.io/developers/developer-zone/receiving-notifications/sns-notifications) - SNS module for Push Delivery Nodes allows any developer to receive notifications, chats, or any other form of web3 communication directly to the platform they are building with the help of webhooks.
+
+### Source Code Verification
+* [Etherscan](https://etherscan.io/) - Ethereum block explorer with contract source code verification functionality 
+* [Sourcify](https://sourcify.dev/) - Decentralized and open-sourced smart contract verification service
+* [Tenderly](https://tenderly.co/) - Web3 development kit with public and private contract verification functionality
 
 ### Distribution
 * [Meroku](https://github.com/merokudao/meroku) - A community owned dApp Store. Package, distribute your dApp without hosting costs.


### PR DESCRIPTION
[Sourcify](https://sourcify.dev/) is a decentralized open-sourced smart contract verification service.

I wanted to add Sourcify as a verification provider to the tools list but I couldn't really find a fitting section. I believe contract verification is a vital step in the contract lifecycle and deserves its own section. I propose adding a "Source Code Verification" section under the [Developer Tools](https://github.com/ConsenSys/ethereum-developer-tools-list#developer-tools) section. Etherscan, Sourcify, and Tenderly are added to the new section as laid out in [ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/verifying/)

So the new format would be:
- [Developer Tools](https://github.com/ConsenSys/ethereum-developer-tools-list#developer-tools)
  - [Developing Smart Contracts](https://github.com/ConsenSys/ethereum-developer-tools-list#developing-smart-contracts)
  - [Other tools](https://github.com/ConsenSys/ethereum-developer-tools-list#other-tools)
  ...
  - [Source Code Verification](https://github.com/ConsenSys/ethereum-developer-tools-list#source-code-verification)
  - [Distribution](https://github.com/ConsenSys/ethereum-developer-tools-list#distribution)

Let me know what you think