### PR TITLE
Add Sepolia Faucet to Test Ether Faucets

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,14 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Kovan faucet](https://github.com/kovan-testnet/faucet)
 * [Goerli faucet1](https://goerlifaucet.com/)
 * [Goerli faucet2](https://goerli-faucet.pk910.de/)
+* [Sepolia faucet1](https://sepoliafaucet.com/)
+* [Sepolia faucet2](https://sepolia-faucet.pk910.de/)
 * [Rinkeby faucet](https://faucet.rinkeby.io/) [DEPRECATED NETWORK]
 * [Ropsten faucet (MetaMask)](https://faucet.metamask.io/) [DEPRECATED NETWORK]
 * [Ropsten faucet (rpanic)](https://faucet.rpanic.com) [DEPRECATED NETWORK]
 * [Universal faucet](https://faucets.blockxlabs.com/)
 * [Nethereum.Faucet](https://github.com/Nethereum/Nethereum.Faucet) - A C#/.NET faucet
-* [Chainlink Faucet](https://faucets.chain.link/rinkeby)
+* [Chainlink Faucet](https://faucets.chain.link/)
 
 ### Communicating with Ethereum
 #### Frontend Ethereum APIs


### PR DESCRIPTION
2 links to the Sepolia test faucet are added.

Also, the chainlink faucet link was broken, now it is fixed.