### PR TITLE
add Calldata Visualizer link to Ethereum ABI tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
 * [Online ABI encoder](https://github.com/HashEx/abiencoder) - Free ABI encoder online service that allows you to encode your Solidity contract’s functions and constructor arguments.
 * [Online Solidity ABI Encoder](https://neptunemutual.com/web3-tools/solidity-abi-encoder-online/) - Online Solidity ABI Encoder to encode smart contract arguments, and also perform read and write operations on the blockchain.
 * [ABI decoder](https://github.com/ConsenSys/abi-decoder) - library for decoding data params and events from Ethereum transactions
+* [ABI Calldata Visualizer](https://purrproof.github.io/calldata-visualizer/) - Interactive calldata visualization.
 * [ABI-gen](https://github.com/0xProject/0x-monorepo/tree/development/packages/abi-gen) - Generate Typescript contract wrappers from contract ABI's.
 * [Ethereum ABI UI](https://github.com/hiddentao/ethereum-abi-ui) - Auto-generate UI form field definitions and associated validators from an Ethereum contract ABI
 * [headlong](https://github.com/esaulpaugh/headlong/) - type-safe Contract ABI and Recursive Length Prefix library in Java


### PR DESCRIPTION
It's a tool which display calldata in clear and interactive manner.
https://purrproof.github.io/calldata-visualizer/
![calldada-visualizer](https://github.com/user-attachments/assets/43bba4fd-ad6c-4c3b-99f6-ddad75e5e842)
