### PR TITLE
feat: add erc1363

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
   * [ERC-721](https://eips.ethereum.org/EIPS/eip-721) - Token standard for non-fungible assets
   * [ERC-777](https://eips.ethereum.org/EIPS/eip-777) - An improved token standard for fungible assets
   * [ERC-918](https://eips.ethereum.org/EIPS/eip-918) - Mineable Token Standard
+  * [ERC-1363](https://eips.ethereum.org/EIPS/eip-1363) - Payable Token Standard
 * [ERC-165](https://eips.ethereum.org/EIPS/eip-165) - Creates a standard method to publish and detect what interfaces a smart contract implements.
 * [ERC-725](https://eips.ethereum.org/EIPS/eip-725) - Proxy contract for key management and execution, to establish a Blockchain identity.
 * [ERC-173](https://eips.ethereum.org/EIPS/eip-173) - A standard interface for ownership of contracts


### PR DESCRIPTION
Add the ERC-1363 Token Standard. 

[ERC-1363](https://eips.ethereum.org/EIPS/eip-1363) is an extension interface for ERC-20 tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.