### PR TITLE
Fix typos and improve clarity in Contribution Guidelines

### DIFF
--- a/contributing-criteria.md
+++ b/contributing-criteria.md
@@ -1,17 +1,17 @@
 # Contribution Guidelines
 
 ## Purpose
-The purpose of the ethereum-developer-tools-list is to direct developers to useful tools, educational resources, and platforms for developing on Ethereum. 
+The purpose of the `ethereum-developer-tools-list` is to direct developers to useful tools, educational resources, and platforms for developing on Ethereum.
 
-As the volume of pull requests has increased and some of the PR's have included tools with little testing, an open discussion is needed to develop a standard for contributions.
+As the volume of pull requests has increased and some of the PRs have included tools with little testing, an open discussion is needed to develop a standard for contributions.
 
-While it may be useful for new projects to gain attention by adding themselves, it may increase the amount of time it takes new developers to find reliable tools that meet their needs. Another goal is to prevent double-work by directing developers to needed tools they can contribute to. 
+While it may be useful for new projects to gain attention by adding themselves, it may also increase the amount of time it takes new developers to find reliable tools that meet their needs. Another goal is to prevent duplicate work by directing developers to needed tools they can contribute to.
 
 ## Format
-Please ensure that your pull request includes a useful title, not just "Update readme.md" 
+Please ensure that your pull request includes a useful title, not just "Update readme.md."
 
-## Criteria for addition 
+## Criteria for Addition
 
-## Scope of list
+## Scope of List
 
 ## Collaborators


### PR DESCRIPTION
- Removed unnecessary apostrophe in "PR's" to "PRs"
- Clarified sentence structure in the Purpose section
- Replaced "double-work" with "duplicate work" for better clarity
- Added missing period in some sentences