### PR TITLE
Add EthTrust to best practices/patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
     * [Blog about Best Practices with Security Audits](https://blog.openzeppelin.com/)
 * [Advanced Workshop with Assembly](https://github.com/androlo/solidity-workshop)
 * [Simpler Ethereum Multisig](https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037) - especially section _Benefits_
+* [EthTrust Security Levels spec](https://entethalliance.org/specs/ethtrust-sl/) - a maintained checklist for security evaluation of Smart Contracts in Solidity, covering kown vulnerabilities.
 * [CryptoFin Solidity Auditing Checklist](https://github.com/cryptofinlabs/audit-checklist) - A checklist of common findings, and issues to watch out for when auditing a contract for a mainnet launch.
 * [aragonOS: A smart contract framework for building DAOs, Dapps and protocols](https://hack.aragon.org/docs/aragonos-intro.html)
     * Upgradeability: Smart contracts can be upgraded to a newer version

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Many thanks to the ~100 contributors including [@corbpage](https://twitter.com/c
     * [Blog about Best Practices with Security Audits](https://blog.openzeppelin.com/)
 * [Advanced Workshop with Assembly](https://github.com/androlo/solidity-workshop)
 * [Simpler Ethereum Multisig](https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037) - especially section _Benefits_
-* [EthTrust Security Levels spec](https://entethalliance.org/specs/ethtrust-sl/) - a maintained checklist for security evaluation of Smart Contracts in Solidity, covering kown vulnerabilities.
+* [EthTrust Security Levels spec](https://entethalliance.org/specs/ethtrust-sl/) - a maintained checklist (see the [Latest Editor's draft](https://github.com/etnethalliance/eta-registry)) for security evaluation of Smart Contracts written in Solidity. This covers known vulnerabilities and attack vectors, including compiler-version specific bugs, broken down into three levels based on difficulty of checking.
 * [CryptoFin Solidity Auditing Checklist](https://github.com/cryptofinlabs/audit-checklist) - A checklist of common findings, and issues to watch out for when auditing a contract for a mainnet launch.
 * [aragonOS: A smart contract framework for building DAOs, Dapps and protocols](https://hack.aragon.org/docs/aragonos-intro.html)
     * Upgradeability: Smart contracts can be upgraded to a newer version

--- a/README_Spanish.md
+++ b/README_Spanish.md
@@ -246,6 +246,7 @@ Muchas gracias a los ~100 contribuidores, incluidos [@corbpage](https://twitter.
     * [Blog sobre prácticas recomendadas con auditorías de seguridad](https://blog.openzeppelin.com/)
 * [Taller avanzado con montaje](https://github.com/androlo/solidity-workshop)
 * [Simpler Ethereum Multisig](https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037) - especialmente la sección _Benefits_
+* [EthTrust Security LEvels Specification](https://entethalliance.org/specs/ethtrust-sl) Una especificación mantenido ([ultima versión borrador del editor](https://github.com/entethalliance/eta-registry)) de pautas para verificar la seguridad de código escrito en Solidity. Da cobertura para los ataques conocidos, incluyendo problemas en versiones especificas del compilador, divididos en tres niveles según la dificultad de verificación.
 * [Lista de verificación de auditoría de Solidity de CryptoFin](https://github.com/cryptofinlabs/audit-checklist) - una lista de verificación de hallazgos comunes y problemas a tener en cuenta al auditar un contrato para el lanzamiento de una red principal.
 * [aragonOS: un framework de contrato inteligente para crear DAO, Dapps y protocolos](https://hack.aragon.org/docs/aragonos-intro.html)
     * Capacidad de actualización: los contratos inteligentes se pueden actualizar a una versión más reciente.


### PR DESCRIPTION
The CryptoFin checklist is lacking in detail, and hasn't been updated for 7 years. EthTrust is up to date, and maintained.